### PR TITLE
Switch to github-style admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@
 
 ## Introduction
 
-:::warning
-This pipeline has been deprecated on June 13, 2024 because it did not meet the quality standards of nf-core.
-Please use the [nf-core/scdownstream](https://nf-co.re/scdownstream) pipeline instead.
-:::
+> [!WARNING]
+> This pipeline has been deprecated on June 13, 2024 because it did not meet the quality standards of nf-core.
+> Please use the [nf-core/scdownstream](https://nf-co.re/scdownstream) pipeline instead.
 
 **nf-core/scflow** is a bioinformatics pipeline for scalable, reproducible, best-practice analyses of single-cell/nuclei RNA-sequencing data.
 


### PR DESCRIPTION
As the previous deprecation not was not correctly displayed in the GitHub repo, this PR switches to using GitHub-Style admonitions